### PR TITLE
set source of %||% to rlang lib, likely due to difference in newer Se…

### DIFF
--- a/R/stratified_test_seurat.R
+++ b/R/stratified_test_seurat.R
@@ -6,7 +6,7 @@ library(pbapply)
 library(future.apply)
 library(Matrix)
 
-`%||%` <- Seurat:::`%||%`
+`%||%` <- rlang::`%||%`
 WilcoxDETest <- Seurat:::WilcoxDETest
 CheckDots <- Seurat:::CheckDots
 GLMDETest <- Seurat:::GLMDETest


### PR DESCRIPTION
…urat versions compared to when this code was first written (for Seurat v3)